### PR TITLE
ci: add flutter workflow with coverage reports

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -65,8 +65,8 @@ jobs:
           fi
 
       - name: Report coverage
-        uses: k1LoW/octocov-action@v1
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: k1LoW/octocov-action@v1
 
       - name: Clean coverage artifacts
         run: rm -rf coverage

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,83 @@
+name: Flutter CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-test:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Generate code
+        run: make build
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests with coverage
+        run: flutter test --coverage
+
+      - name: Report coverage
+        uses: k1LoW/octocov-action@v1
+
+      - name: Clean coverage artifacts
+        run: rm -rf coverage
+
+      - name: Restore badges on non-default branches
+        if: github.ref != 'refs/heads/master'
+        run: |
+          for badge in docs/coverage.svg docs/code_to_test_ratio.svg docs/test_execution_time.svg; do
+            if git ls-files --error-unmatch "$badge" >/dev/null 2>&1; then
+              git checkout -- "$badge"
+            fi
+          done
+
+      - name: Verify no generated changes
+        run: |
+          git diff --exit-code
+          untracked=$(git ls-files --others --exclude-standard)
+          if [ -n "$untracked" ]; then
+            echo "Error: untracked files detected" >&2
+            echo "$untracked" >&2
+            exit 1
+          fi

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -57,8 +57,16 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
+      - name: Check coverage file exists
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            echo "Coverage file not found!"
+            exit 1
+          fi
+
       - name: Report coverage
         uses: k1LoW/octocov-action@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 
       - name: Clean coverage artifacts
         run: rm -rf coverage

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,39 @@
+coverage:
+  paths:
+    - coverage/lcov.info
+  badge:
+    path: docs/coverage.svg
+
+code_to_test_ratio:
+  code:
+    - lib
+  test:
+    - test
+  badge:
+    path: docs/code_to_test_ratio.svg
+
+test_execution_time:
+  steps:
+    - Run tests with coverage
+  badge:
+    path: docs/test_execution_time.svg
+
+summary:
+  if: true
+
+comment:
+  if: is_pull_request
+
+diff:
+  if: is_pull_request
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
+push:
+  if: is_default_branch
+  message: 'chore: update coverage badge by octocov [skip ci]'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MatchNotes
 
+[![Coverage](docs/coverage.svg)](https://github.com/dohq/matchnotes/actions/workflows/flutter-ci.yml)
+[![Code to Test Ratio](docs/code_to_test_ratio.svg)](https://github.com/dohq/matchnotes/actions/workflows/flutter-ci.yml)
+[![Test Execution Time](docs/test_execution_time.svg)](https://github.com/dohq/matchnotes/actions/workflows/flutter-ci.yml)
+
  Android向け・ローカルSQLiteベースの「勝敗記録アプリ」。
 
 ## 開発手順

--- a/docs/code_to_test_ratio.svg
+++ b/docs/code_to_test_ratio.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="162" height="20" role="img" aria-label="code:test: pending">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="162" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="87" height="20" fill="#555"/>
+    <rect x="87" width="75" height="20" fill="#9f9f9f"/>
+    <rect width="162" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="44" y="15" fill="#010101" fill-opacity=".3">code:test</text>
+    <text x="44" y="14">code:test</text>
+    <text x="124" y="15" fill="#010101" fill-opacity=".3">pending</text>
+    <text x="124" y="14">pending</text>
+  </g>
+</svg>

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="138" height="20" role="img" aria-label="coverage: pending">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="138" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="73" height="20" fill="#555"/>
+    <rect x="73" width="65" height="20" fill="#9f9f9f"/>
+    <rect width="138" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="37" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="37" y="14">coverage</text>
+    <text x="105" y="15" fill="#010101" fill-opacity=".3">pending</text>
+    <text x="105" y="14">pending</text>
+  </g>
+</svg>

--- a/docs/test_execution_time.svg
+++ b/docs/test_execution_time.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="182" height="20" role="img" aria-label="test time: pending">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="182" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="97" height="20" fill="#555"/>
+    <rect x="97" width="85" height="20" fill="#9f9f9f"/>
+    <rect width="182" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="49" y="15" fill="#010101" fill-opacity=".3">test time</text>
+    <text x="49" y="14">test time</text>
+    <text x="139" y="15" fill="#010101" fill-opacity=".3">pending</text>
+    <text x="139" y="14">pending</text>
+  </g>
+</svg>


### PR DESCRIPTION
## 概要
- Flutter CI ワークフローを追加し、format / analyze / test / coverage / Octocov を自動化
- Octocov 設定と README バッジ (coverage / code:test ratio / test time) を追加
- 生成物コミット漏れ検知 (git diff --exit-code + 未追跡ファイルチェック) を導入

## 確認したこと
- [x] flutter test test/presentation/settings_page_test.dart
- [x] GitHub Actions 上での結果（PR 作成後に確認）