### PR TITLE
test: CSVユースケースとDBオープンのカバレッジ強化

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -577,7 +577,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   drift_dev: ^2.18.0
   build_runner: ^2.4.13
+  path_provider_platform_interface: ^2.1.2
 
 flutter:
   uses-material-design: true

--- a/test/domain/export_daily_records_csv_test.dart
+++ b/test/domain/export_daily_records_csv_test.dart
@@ -1,8 +1,12 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matchnotes/domain/entities.dart';
 import 'package:matchnotes/domain/usecases/export_daily_records_csv.dart';
+import 'package:matchnotes/infrastructure/db/app_database.dart';
+import 'package:matchnotes/infrastructure/repositories/daily_character_record_repository_drift.dart';
 
 import 'fakes.dart';
 
@@ -45,6 +49,55 @@ void main() {
       // Sorted by gameId asc, then characterId asc, then date asc
       expect(lines[1], 'gA,c2,20250101,2,3');
       expect(lines[2], 'gB,c1,20250102,1,0');
+    });
+
+    test('writes extended csv with names when db is provided', () async {
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(() async => db.close());
+      final repo = DailyCharacterRecordRepositoryDrift(db);
+      final usecase = ExportDailyRecordsCsvUsecase(repo, db);
+
+      await db.upsertGame(
+        GamesCompanion(id: const Value('g1'), name: const Value('Game A')),
+      );
+      await db.upsertCharacter(
+        CharactersCompanion.insert(id: 'c1', gameId: 'g1', name: 'Char A'),
+      );
+
+      final d1 = DateTime(2024, 1, 1);
+      final d2 = DateTime(2024, 1, 2);
+      await repo.upsert(
+        DailyCharacterRecord(
+          id: DailyCharacterRecordId(gameId: 'g2', characterId: 'c9', date: d2),
+          wins: 0,
+          losses: 2,
+          memo: '',
+        ),
+      );
+      await repo.upsert(
+        DailyCharacterRecord(
+          id: DailyCharacterRecordId(gameId: 'g1', characterId: 'c1', date: d1),
+          wins: 5,
+          losses: 4,
+          memo: null,
+        ),
+      );
+
+      final temp = await Directory.systemTemp.createTemp(
+        'export_csv_with_names',
+      );
+      addTearDown(() async => temp.delete(recursive: true));
+
+      final file = await usecase.execute(targetDir: temp);
+      final content = await file.readAsString();
+      final lines = content.trim().split('\n');
+
+      expect(
+        lines.first,
+        'game_id,character_id,game_name,character_name,yyyymmdd,wins,losses',
+      );
+      expect(lines[1], 'g1,c1,Game A,Char A,20240101,5,4');
+      expect(lines[2], 'g2,c9,g2,c9,20240102,0,2');
     });
   });
 }

--- a/test/domain/import_daily_records_csv_test.dart
+++ b/test/domain/import_daily_records_csv_test.dart
@@ -55,5 +55,86 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'imports extended CSV, populates master data, and stores records',
+      () async {
+        final repo = FakeDailyCharacterRecordRepository();
+        final db = AppDatabase(NativeDatabase.memory());
+        addTearDown(() async => db.close());
+
+        final usecase = ImportDailyRecordsCsvUsecase(repo, db);
+
+        final csv = [
+          'game_id,character_id,game_name,character_name,yyyymmdd,wins,losses',
+          'g1,c1,Game Alpha,Char One,20240201,3,1',
+          'g3,c3,Game Gamma,Char Three,20240202,0,0',
+        ].join('\n');
+
+        final dir = await Directory.systemTemp.createTemp(
+          'import_csv_extended',
+        );
+        addTearDown(() async => dir.delete(recursive: true));
+        final file = File('${dir.path}/in.csv');
+        await file.writeAsString(csv);
+
+        final report = await usecase.executeWithReport(file: file);
+        expect(report.imported, 2);
+        expect(report.skipped, 0);
+        expect(report.errors, isEmpty);
+
+        final games = await db.fetchAllGames();
+        expect(games.map((g) => g.id), containsAll(['g1', 'g3']));
+
+        final charactersG1 = await db.fetchCharactersByGame('g1');
+        expect(charactersG1.map((c) => c.id), contains('c1'));
+        expect(charactersG1.firstWhere((c) => c.id == 'c1').name, 'Char One');
+
+        final charactersG3 = await db.fetchCharactersByGame('g3');
+        expect(charactersG3.map((c) => c.id), contains('c3'));
+
+        final stored = repo.dump();
+        expect(stored.length, 2);
+        expect(
+          stored.any(
+            (r) =>
+                r.id.gameId == 'g1' && r.id.characterId == 'c1' && r.wins == 3,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('skips invalid rows and reports details', () async {
+      final repo = FakeDailyCharacterRecordRepository();
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(() async => db.close());
+      final usecase = ImportDailyRecordsCsvUsecase(repo, db);
+
+      final csv = [
+        'game_id,character_id,yyyymmdd,wins,losses',
+        ',c0,20250101,1,0',
+        'g1,c1,zzz,0,1',
+        'g1,c2,20250132,1,0',
+        'g1,c3,20250103,-1,0',
+        'g1,c4,20250104,1',
+      ].join('\n');
+
+      final dir = await Directory.systemTemp.createTemp('import_csv_errors');
+      addTearDown(() async => dir.delete(recursive: true));
+      final file = File('${dir.path}/bad.csv');
+      await file.writeAsString(csv);
+
+      final report = await usecase.executeWithReport(file: file);
+      expect(report.imported, 0);
+      expect(report.skipped, 5);
+      expect(report.errors.length, 5);
+      expect(report.errors, contains('line 2: game_id または character_id が空です'));
+      expect(report.errors, contains('line 3: 数値項目の形式が不正です'));
+      expect(report.errors, contains('line 4: yyyymmdd が不正な日付です'));
+      expect(report.errors, contains('line 5: wins または losses が負の値です'));
+      expect(report.errors, contains('line 6: 列数が不足しています'));
+      expect(repo.dump(), isEmpty);
+    });
   });
 }

--- a/test/infrastructure/db/open_test.dart
+++ b/test/infrastructure/db/open_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matchnotes/infrastructure/db/open.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.appSupportPath);
+
+  final String appSupportPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => appSupportPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PathProviderPlatform original;
+
+  setUp(() {
+    original = PathProviderPlatform.instance;
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = original;
+  });
+
+  test(
+    'openAppDatabase creates database file under application support dir',
+    () async {
+      final temp = await Directory.systemTemp.createTemp('open_app_database');
+      addTearDown(() async => temp.delete(recursive: true));
+
+      PathProviderPlatform.instance = _FakePathProvider(temp.path);
+
+      final db = await openAppDatabase();
+      addTearDown(() async => db.close());
+
+      await db.customSelect('SELECT 1').getSingle();
+
+      final expectedPath = p.join(temp.path, 'matchnotes.db');
+      expect(File(expectedPath).existsSync(), isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## 概要
- CSVエクスポート/インポートのユースケースを拡張カバレッジで検証
- DBオープン処理のパス解決をプラットフォームスタブで確認

## テスト
- flutter test test/domain/export_daily_records_csv_test.dart test/domain/import_daily_records_csv_test.dart test/infrastructure/db/open_test.dart