### PR TITLE
fix(domain): allow clearing memo in DailyCharacterRecord

### DIFF
--- a/lib/domain/entities.dart
+++ b/lib/domain/entities.dart
@@ -48,6 +48,8 @@ bool _isSameDay(DateTime a, DateTime b) {
   return a.year == b.year && a.month == b.month && a.day == b.day;
 }
 
+const _memoSentinel = Object();
+
 class DailyCharacterRecord {
   final DailyCharacterRecordId id;
   final int wins;
@@ -60,12 +62,16 @@ class DailyCharacterRecord {
     this.memo,
   });
 
-  DailyCharacterRecord copyWith({int? wins, int? losses, String? memo}) {
+  DailyCharacterRecord copyWith({
+    int? wins,
+    int? losses,
+    Object? memo = _memoSentinel,
+  }) {
     return DailyCharacterRecord(
       id: id,
       wins: wins ?? this.wins,
       losses: losses ?? this.losses,
-      memo: memo ?? this.memo,
+      memo: identical(memo, _memoSentinel) ? this.memo : memo as String?,
     );
   }
 }

--- a/test/domain/entities_test.dart
+++ b/test/domain/entities_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matchnotes/domain/entities.dart';
+
+void main() {
+  group('DailyCharacterRecord.copyWith', () {
+    final id = DailyCharacterRecordId(
+      gameId: 'g1',
+      characterId: 'c1',
+      date: DateTime(2024, 5, 20),
+    );
+
+    test('retains existing values when fields are not provided', () {
+      final record = DailyCharacterRecord(
+        id: id,
+        wins: 3,
+        losses: 1,
+        memo: 'note',
+      );
+
+      final updated = record.copyWith();
+
+      expect(updated.wins, 3);
+      expect(updated.losses, 1);
+      expect(updated.memo, 'note');
+    });
+
+    test('allows clearing memo by passing null explicitly', () {
+      final record = DailyCharacterRecord(
+        id: id,
+        wins: 3,
+        losses: 1,
+        memo: 'note',
+      );
+
+      final cleared = record.copyWith(memo: null);
+
+      expect(cleared.memo, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow DailyCharacterRecord.copyWith to explicitly clear memo values by introducing a sentinel parameter
- add unit tests covering memo retention and clearing behavior

## Testing
- not run (flutter/dart SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d54ac4dfdc832faa525e0db8b9dbe2